### PR TITLE
[WIP] add additional auth tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,21 @@ export default Ember.Route.extend({
 });
 ```
 
-#### Session service API
+### Generating an unauthorized route
+
+If your app distinguishes between authorized and un-authorized users (eg. not all authenticated users are authorized), you will probably want to redirect unauthorized users to a page explaining what happened. This addon contains a custom generator for creating this automagically.
+
+##### Requirements: 
+* a named `unauthorized` outlet in your application template: `{{outlet 'unauthorized'}}`
+
+##### Usage: 
+
+* `ember generate unauthorized-route` will create a route named `unauthorized` and add it to your app's router.
+* `ember generate unauthorized-route aw-hells-no` will create the same but with your custom name (`aw-hells-no` in this case).
+
+This generator will use your app's pod configuration and also accepts ember-cli's `--pod` flag.
+
+### Session service API
 
 API | Type | About | Returns | Example
 --- | --- | --- | --- | ---

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ like current user, from your TED backend.
 
 * JSONAPI
 * Your application must have a `User` model.
+* If using authorization, your `User` model must have an `isAuthorized` property
 
 ## Install
 
@@ -57,7 +58,8 @@ export default Ember.Route.extend({
   actions: {
     login(email, password) {
       this.get('tedSession')
-        .login(email, password)
+        .login(email
+          , password)
         .then(() => console.log('it worked'))
         .catch(() => console.loa('nope'));
     }
@@ -75,6 +77,7 @@ API | Type | About | Returns | Example
 `currentUser` | `property` | Returns the current user | `User DS.Model` | `tedSession.get('currentUser')`
 `isLoggedIn` | `property` | Is there a current user | `Boolean` | `tedSession.get('isLoggedIn')`
 `isNotLoggedIn` | `property` | Is there no current user | `Boolean` | `tedSession.get('isNotLoggedIn')`
+`isAuthorized` | `property` | Returns `isAuthorized` property of the current user model, `false` if unavailable. | `Boolean` | `tedSession.get('isAuthorized')`
 
 ## Details
 
@@ -97,6 +100,7 @@ The get expects a JSON API document.
     },
     "relationships": {
       "user": {
+        `isAuthorized`: true // optional 
         "links": {
           "self": "/ted-sessions/current/relationships/user",
           "related": "/ted-sessions/current/user"

--- a/addon/services/ted-session.js
+++ b/addon/services/ted-session.js
@@ -8,6 +8,7 @@ export default Ember.Service.extend({
   currentUser: Ember.computed.readOnly('model.user'),
   isLoggedIn: Ember.computed.bool('model.user.id'),
   isNotLoggedIn: Ember.computed.not('isLoggedIn'),
+  isAuthorized: Ember.computed.bool('model.user.isAuthorized'),
 
   login(email, password) {
     return this.get('store')

--- a/blueprints/.jshintrc
+++ b/blueprints/.jshintrc
@@ -1,0 +1,6 @@
+{
+  "predef": [
+    "console"
+  ],
+  "strict": false
+}

--- a/blueprints/unauthorized-route/files/app/__routepath__/__routename__.js
+++ b/blueprints/unauthorized-route/files/app/__routepath__/__routename__.js
@@ -1,0 +1,15 @@
+import Ember from 'ember';
+
+export default Ember.Route.extend({
+  tedSession: Ember.inject.service(),
+  beforeModel() {
+    if (this.get('tedSession.isAuthorized')) {
+      this.transitionTo('/');
+    }
+  },
+  renderTemplate() {
+    this.render('unauthorized', {
+      outlet: 'unauthorized'
+    });
+  }
+});

--- a/blueprints/unauthorized-route/files/app/__templatepath__/__templatename__.hbs
+++ b/blueprints/unauthorized-route/files/app/__templatepath__/__templatename__.hbs
@@ -1,0 +1,7 @@
+<div class="Unauthorized-message">  
+  <h1>You are not authorized to view this application</h1>
+  <br>
+  {{!-- Customize your message below: --}}
+  <p>If you think this might be an error, please <a href="mailto:tech@ted.com?subject=%20request%20for%20<%=classifiedPackageName %>%20app%20access%20">contact the TED Tech Team</a>.</p>
+  <br>
+</div>

--- a/blueprints/unauthorized-route/index.js
+++ b/blueprints/unauthorized-route/index.js
@@ -1,0 +1,88 @@
+var fs = require('fs-extra');
+var path = require('path');
+var EmberRouterGenerator = require('ember-router-generator');
+
+/*jshint node:true*/
+module.exports = {
+
+  // usage: ember g unauthorized-route
+  description: 'Generates an unauthorized route and template and registers the route with the router.',
+
+  normalizeEntityName: function(entityName){
+    return entityName || "unauthorized";
+  },
+
+  fileMapTokens: function() {
+    return {
+      __templatepath__: function(options) {
+        if (options.pod) {
+          return path.join(options.podPath, options.dasherizedModuleName);
+        }
+        return 'templates';
+      },
+      __templatename__: function(options) {
+        if (options.pod) {
+          return 'template';
+        }
+        return options.dasherizedModuleName;
+      },
+      __routepath__: function(options) {
+        if (options.pod) {
+          return path.join(options.podPath, options.dasherizedModuleName);
+        }
+        return 'routes';
+      },
+      __routename__: function(options) {
+        if (options.pod) {
+          return 'route';
+        }
+        return options.dasherizedModuleName;
+      }
+    }
+  },
+
+  afterInstall: function(options) {
+    updateRouter.call(this, 'add', options);
+    addOutlet.call(this, options);
+  },
+
+  afterUninstall: function(options) {
+    updateRouter.call(this, 'remove', options);
+  }
+};
+
+function updateRouter(action, options) {
+  var entity = options.entity;
+  var actionColorMap = {
+    add: 'green',
+    remove: 'red'
+  };
+  var color = actionColorMap[action] || 'gray';
+
+  writeRoute(action, entity.name, options);
+
+  this.ui.writeLine('updating router');
+  this.ui.writeLine(`${action} route ${entity.name}`)
+}
+
+function findRouter(options) {
+  var routerPathParts = [options.project.root];
+
+  if (options.dummy && options.project.isEmberCLIAddon()) {
+    routerPathParts = routerPathParts.concat(['tests', 'dummy', 'app', 'router.js']);
+  } else {
+    routerPathParts = routerPathParts.concat(['app', 'router.js']);
+  }
+
+  return routerPathParts;
+}
+
+function writeRoute(action, name, options) {
+  var routerPath = path.join.apply(null, findRouter(options));
+  var source = fs.readFileSync(routerPath, 'utf-8');
+
+  var routes = new EmberRouterGenerator(source);
+  var newRoutes = routes[action](name, options);
+
+  fs.writeFileSync(routerPath, newRoutes.code());
+}

--- a/package.json
+++ b/package.json
@@ -41,7 +41,9 @@
     "ember-addon"
   ],
   "dependencies": {
-    "ember-cli-babel": "^5.1.5"
+    "ember-cli-babel": "^5.1.5",
+    "ember-router-generator": "^1.2.3",
+    "fs-extra": "^2.0.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"


### PR DESCRIPTION
* expose and `isAuthorized` property if available on the User model
* adds a generator for creating an `unauthorized` route as specified by our conventional auth setup (see https://tech-guides.ted.com/guides/donkey/auth_flow.html)

additional things that would be nice to add expand on this:
- [ ] auto-add the`{{outlet 'unauthorized'}}` when the generator runs
- [ ] additional session service methods or a route mixin to supply application wide auth routing  (see https://github.com/tedconf/donkey-frontend/blob/2267fe5d07f3273b3b12f8b85028826818dc2ac8/app/pods/application/route.js)